### PR TITLE
Add quarkus-kubernetes dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-kubernetes</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jsonp</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
It's necessary to add the `quarkus-kubernetes` dependency to be fully compatible with the workflow plugin for the Knative CLI.