### PR TITLE
[Quarkus accelerator] Use Kogito Runtimes `1.40.0.Final`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,11 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.16.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.16.7.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+    <kogito.bom.group-id>org.kie.kogito</kogito.bom.group-id>
+    <kogito.bom.artifact-id>kogito-bom</kogito.bom.artifact-id>
+    <kogito.bom.version>1.40.0.Final</kogito.bom.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -26,9 +29,9 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>${quarkus.platform.group-id}</groupId>
-        <artifactId>quarkus-kogito-bom</artifactId>
-        <version>${quarkus.platform.version}</version>
+        <groupId>${kogito.bom.group-id}</groupId>
+        <artifactId>${kogito.bom.artifact-id}</artifactId>
+        <version>${kogito.bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -50,6 +53,10 @@
     <dependency>
       <groupId>org.kie.kogito</groupId>
       <artifactId>kogito-addons-quarkus-source-files</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.kie.kogito</groupId>
+      <artifactId>kogito-addons-quarkus-jobs-service-embedded</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/src/main/resources/META-INF/resources/index.html
+++ b/src/main/resources/META-INF/resources/index.html
@@ -266,7 +266,7 @@
                         <li>GroupId: <code>org.kie.kogito</code></li>
                         <li>ArtifactId: <code>serverless-logic-web-tools-project</code></li>
                         <li>Version: <code>0.0.0</code></li>
-                        <li>Quarkus Version: <code>2.16.6.Final</code></li>
+                        <li>Quarkus Version: <code>2.16.7.Final</code></li>
                     </ul>
                 </div>
             </div>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,6 +4,11 @@ quarkus.http.cors.origins=*
 quarkus.http.host=0.0.0.0
 quarkus.http.enable-compression=true
 quarkus.http.port=8080
+quarkus.devservices.enabled=false
+
+quarkus.log.category."org.kie.kogito.jobs".level=ERROR
+quarkus.log.category."io.zonky".level=ERROR
+quarkus.log.category."org.flywaydb.".level=ERROR
 
 kogito.dev-ui.url=${KOGITO_DEV_UI_URL:http://localhost:8080}
 kogito.data-index.url=${KOGITO_DATA_INDEX_URL:http://localhost:8080}


### PR DESCRIPTION
Also in this PR:
- Bump Quarkus version to `2.16.7.Final`
- Add `kogito-addons-quarkus-jobs-service-embedded` dependency
- Suppress some database logs that are not ERROR 