### PR TITLE
NO-ISSUE: Fix one apache repo leftover and changed repository urls to repo vars

### DIFF
--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: kubesmarts/kie-tools
+          repository: ${{ vars.KIE_TOOLS_REPO }}
 
       # This bash script will set an output version for this step. It can be used with steps.version.outputs.version
       - name: "Output version"
@@ -98,7 +98,7 @@ jobs:
         with:
           token: ${{ github.event_name != 'pull_request' && secrets.KIE_GROUP_TOOLS_TOKEN || secrets.GITHUB_TOKEN }}
           path: serverless-logic-sandbox-deployment
-          repository: kiegroup/serverless-logic-sandbox-deployment
+          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       - name: "Update serverless-logic-sandbox-deployment resources"

--- a/.github/workflows/daily_dev_publish.yml
+++ b/.github/workflows/daily_dev_publish.yml
@@ -12,6 +12,10 @@ concurrency:
   group: ${{ github.event.pull_request && format('daily-dev-publish-pr-{0}', github.event.pull_request.number) || format('daily-dev-publish-ref-{0}', github.ref_name) }}
   cancel-in-progress: true
 
+env:
+  KIE_TOOLS_REPO: ${{ vars.KIE_TOOLS_REPO || 'kubesmarts/kie-tools' }}
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kiegroup/serverless-logic-sandbox-deployment' }}
+
 jobs:
   build:
     if: github.repository == 'kiegroup/serverless-logic-sandbox-deployment'
@@ -48,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: ${{ vars.KIE_TOOLS_REPO }}
+          repository: ${{ env.KIE_TOOLS_REPO  }}
 
       # This bash script will set an output version for this step. It can be used with steps.version.outputs.version
       - name: "Output version"
@@ -98,7 +102,7 @@ jobs:
         with:
           token: ${{ github.event_name != 'pull_request' && secrets.KIE_GROUP_TOOLS_TOKEN || secrets.GITHUB_TOKEN }}
           path: serverless-logic-sandbox-deployment
-          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       - name: "Update serverless-logic-sandbox-deployment resources"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -85,7 +85,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: kubesmarts/kie-tools
+          repository: ${{ vars.KIE_TOOLS_REPO }}
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         if: ${{ !inputs.dry_run }}
@@ -94,7 +94,7 @@ jobs:
           path: ${{ github.workspace }}/serverless-logic-sandbox-deployment
           fetch-depth: 0
           token: ${{ secrets.kie_group_tools_token }}
-          repository: kiegroup/serverless-logic-sandbox-deployment
+          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       - name: "Cache Maven packages"

--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -28,6 +28,8 @@ on:
         required: false
 
 env:
+  KIE_TOOLS_REPO: ${{ vars.KIE_TOOLS_REPO || 'kubesmarts/kie-tools' }}
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kiegroup/serverless-logic-sandbox-deployment' }}
   KIE_TOOLS_BUILD__runLinters: "false"
   KIE_TOOLS_BUILD__runTests: "false"
   KIE_TOOLS_BUILD__runEndToEndTests: "false"
@@ -85,7 +87,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: ${{ vars.KIE_TOOLS_REPO }}
+          repository: ${{ env.KIE_TOOLS_REPO }}
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         if: ${{ !inputs.dry_run }}
@@ -94,7 +96,7 @@ jobs:
           path: ${{ github.workspace }}/serverless-logic-sandbox-deployment
           fetch-depth: 0
           token: ${{ secrets.kie_group_tools_token }}
-          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       - name: "Cache Maven packages"

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: apache/incubator-kie-tools
+          repository: ${{ vars.KIE_TOOLS_REPO }}
           ref: ${{ fromJSON(steps.fetch_release_for_tag.outputs.data).target_commitish }}
 
       - name: "Check `tag` against `(package.json).version`"
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: serverless-logic-sandbox-deployment
-          repository: kiegroup/serverless-logic-sandbox-deployment
+          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
 
   build_and_publish:
     needs: [prepare]

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -13,6 +13,10 @@ on:
         description: "Jobs to run (JSON)"
         default: '{"serverless_logic_web_tools":"true"}'
 
+env:
+  KIE_TOOLS_REPO: ${{ vars.KIE_TOOLS_REPO || 'kubesmarts/kie-tools' }}
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kiegroup/serverless-logic-sandbox-deployment' }}
+
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -34,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: ${{ vars.KIE_TOOLS_REPO }}
+          repository: ${{ env.KIE_TOOLS_REPO }}
           ref: ${{ fromJSON(steps.fetch_release_for_tag.outputs.data).target_commitish }}
 
       - name: "Check `tag` against `(package.json).version`"
@@ -48,7 +52,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: serverless-logic-sandbox-deployment
-          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
 
   build_and_publish:
     needs: [prepare]

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -31,6 +31,10 @@ on:
       gh_token:
         required: false
 
+env:
+  KIE_TOOLS_REPO: ${{ vars.KIE_TOOLS_REPO || 'kubesmarts/kie-tools' }}
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kiegroup/serverless-logic-sandbox-deployment' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -57,7 +61,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: ${{ vars.KIE_TOOLS_REPO }}
+          repository: ${{ env.KIE_TOOLS_REPO }}
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         if: ${{ !inputs.dry_run }}
@@ -66,7 +70,7 @@ jobs:
           path: ${{ github.workspace }}/serverless-logic-sandbox-deployment
           fetch-depth: 0
           token: ${{ secrets.kie_group_tools_token }}
-          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       # Skipped MacOS and Windows due to 120s timeout being reached while running hashFiles('**/pom.xml')

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -103,7 +103,7 @@ jobs:
           WEBPACK__minimize: "true"
           WEBPACK__tsLoaderTranspileOnly: "false"
 
-          SERVERLESS_LOGIC_WEB_TOOLS__version: "${{ inputs.tag }}-prerelease"
+          SERVERLESS_LOGIC_WEB_TOOLS__version: "${{ inputs.tag }}"
           SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryOrg: "kubesmarts" 
           SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryName: "sandbox-catalog"
           SERVERLESS_LOGIC_WEB_TOOLS__samplesRepositoryRef: "${{ inputs.tag }}"
@@ -116,7 +116,7 @@ jobs:
         if: ${{ !inputs.dry_run }}
         working-directory: ${{ github.workspace }}/serverless-logic-sandbox-deployment
         env:
-          DEPLOYMENT_DIR: staging/${{ inputs.tag }}-prerelease
+          DEPLOYMENT_DIR: staging/${{ inputs.tag }}
         run: |
           echo "Reset deployment dir"
           rm -rf $DEPLOYMENT_DIR
@@ -126,7 +126,7 @@ jobs:
 
           echo "Commit changes and push"
           git add $DEPLOYMENT_DIR
-          git commit -m "Deploy ${{ inputs.tag }}-prerelease (staging)"
+          git commit -m "Deploy ${{ inputs.tag }} (staging)"
           git push origin gh-pages
 
           echo "Clean up serverless-logic-sandbox-deployment dir"

--- a/.github/workflows/staging_build.yml
+++ b/.github/workflows/staging_build.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: kubesmarts/kie-tools
+          repository: ${{ vars.KIE_TOOLS_REPO }}
 
       - name: "Checkout serverless-logic-sandbox-deployment"
         if: ${{ !inputs.dry_run }}
@@ -66,7 +66,7 @@ jobs:
           path: ${{ github.workspace }}/serverless-logic-sandbox-deployment
           fetch-depth: 0
           token: ${{ secrets.kie_group_tools_token }}
-          repository: kiegroup/serverless-logic-sandbox-deployment
+          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
           ref: gh-pages
 
       # Skipped MacOS and Windows due to 120s timeout being reached while running hashFiles('**/pom.xml')

--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -12,6 +12,10 @@ concurrency:
   group: staging-publish
   cancel-in-progress: true
 
+env:
+  KIE_TOOLS_REPO: ${{ vars.KIE_TOOLS_REPO || 'kubesmarts/kie-tools' }}
+  SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO || 'kiegroup/serverless-logic-sandbox-deployment' }}
+
 jobs:
   create_release:
     runs-on: ubuntu-latest
@@ -26,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: ${{ vars.KIE_TOOLS_REPO }}
+          repository: ${{ env.KIE_TOOLS_REPO }}
           ref: ${{ github.event.inputs.version }}
 
       - name: "Parse `commit_sha`"
@@ -63,7 +67,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: serverless-logic-sandbox-deployment
-          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
+          repository: ${{ env.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
 
   build_and_publish:
     needs: [create_release]

--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: kie-tools
-          repository: apache/incubator-kie-tools
-          ref: ${{ github.event.inputs.version }}-prerelease
+          repository: ${{ vars.KIE_TOOLS_REPO }}
+          ref: ${{ github.event.inputs.version }}
 
       - name: "Parse `commit_sha`"
         id: release_draft_commit_sha
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: serverless-logic-sandbox-deployment
-          repository: kiegroup/serverless-logic-sandbox-deployment
+          repository: ${{ vars.SERVERLESS_LOGIC_SANDBOX_DEPLOYMENT_REPO }}
 
   build_and_publish:
     needs: [create_release]


### PR DESCRIPTION
This PR fixes one Apache repository URL leftover and uses repo vars instead of hardcoded URLs.
I also removed the `-prerelease` from the branch name in the WF below as we don't have these branches ATM.
`.github/workflows/staging_publish.yml`