### PR TITLE
NO-ISSUE: staging_publishing job not checking the right directory

### DIFF
--- a/.github/workflows/staging_publish.yml
+++ b/.github/workflows/staging_publish.yml
@@ -38,7 +38,9 @@ jobs:
       - name: "Check `version` against `package.json.version`"
         shell: bash
         run: |
+          cd kie-tools
           [ "${{ github.event.inputs.version }}" == "$(node -p "require('./package.json').version")" ]
+          cd -
 
       - name: "Create Release (draft)"
         id: create_release_draft


### PR DESCRIPTION
The workflow is not correctly locating the package.json. 

See:
https://github.com/kiegroup/serverless-logic-sandbox-deployment/actions/runs/12948911768